### PR TITLE
Add support for use in lazy loaded modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,35 @@ cordova plugin add cordova-plugin-file cordova-plugin-file-transfer
 ``` ts
 //app.module.ts
 
-import { NgModule }      from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { FormsModule }   from '@angular/forms';
+import { ErrorHandler, NgModule } from '@angular/core';
+import { IonicApp, IonicErrorHandler, IonicModule } from 'ionic-angular';
+import { SplashScreen } from '@ionic-native/splash-screen';
+import { StatusBar } from '@ionic-native/status-bar';
 import { ImgCacheModule } from 'ng-imgcache';
 
-import { AppComponent }  from './app.component';
+import { MyApp } from './app.component';
+import { HomePage } from '../pages/home/home';
 
 @NgModule({
+  declarations: [
+    MyApp,
+    HomePage
+  ], 
   imports: [
     BrowserModule,
-    FormsModule,
-    ImgCacheModule
+    IonicModule.forRoot(MyApp) 
   ],
-  declarations: [
-    AppComponent
+  bootstrap: [IonicApp],
+  entryComponents: [
+    MyApp,
+    HomePage
   ],
-  bootstrap: [ AppComponent ]
+  providers: [
+    StatusBar,
+    SplashScreen,
+    {provide: ErrorHandler, useClass: IonicErrorHandler}
+  ] 
 })
 export class AppModule {}
 ```
@@ -81,7 +93,33 @@ export class MyApp {
 }
 ```
 
-**4. Use the directive in your component templates:**
+**4. (Optional) Import the `ImgCacheModule` in your lazy loaded page modules:**
+
+``` ts
+//lazy.module.ts
+
+import { NgModule }      from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { ImgCacheModule } from 'ng-imgcache';
+
+import { LazyPage }  from './lazy';
+
+@NgModule({
+  declarations: [
+    LazyPage
+  ],
+  imports: [
+    IonicPageModule.forChild(LazyPage),
+    ImgCacheModule.forChild()
+  ],
+  exports: [
+    LazyPage
+  ]
+})
+export class LazyPageModule {}
+```
+
+**5. Use the directive in your component templates:**
 
 ``` ts
 import { Component } from '@angular/core';

--- a/src/img-cache.module.ts
+++ b/src/img-cache.module.ts
@@ -14,12 +14,12 @@ export class ImgCacheModule {
       providers: [
         ImgCacheService
       ]
-    }
+    };
   }
 
   static forChild(): ModuleWithProviders {
     return {
       ngModule: ImgCacheModule
-    }
+    };
   }
 }

--- a/src/img-cache.module.ts
+++ b/src/img-cache.module.ts
@@ -5,7 +5,21 @@ import { ImgCacheService } from './img-cache.service';
 
 @NgModule({
   declarations: [ ImgCacheDirective ],
-  exports: [ ImgCacheDirective ],
-  providers: [ ImgCacheService ]
+  exports: [ ImgCacheDirective ]
 })
-export class ImgCacheModule {}
+export class ImgCacheModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: ImgCacheModule,
+      providers: [
+        ImgCacheService
+      ]
+    }
+  }
+
+  static forChild(): ModuleWithProviders {
+    return {
+      ngModule: ImgCacheModule
+    }
+  }
+}


### PR DESCRIPTION
If `ImgCacheModule` was imported in different lazy loaded modules, then each of them got their own instance of `ImgCacheService`. In additional instances `init()` was never called. Therefore, caching didn't work.

I added standard `forRoot()` and `forChild()` methods to resolve the issue:

- In `app.module.ts`, `ImgCacheService.forRoot()` needs to be imported. It registers `ImgCacheService` with the injector.
- In other lazy loaded modules, `ImgCacheService.forChild()` needs to be imported. It doesn't register `ImgCacheService` so that the injector in lazy loaded modules still returns the instance from `AppModule`.

Reference blog post: http://weblogs.thinktecture.com/thomas/2017/05/the-real-secrets-behind-forroot-andor-forchild-of-an-ngmodule.html