### PR TITLE
メソッド修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,4 +95,3 @@ Temporary Items
 
 # Compilation directories
 aot/
-dist/

--- a/dist/img-cache.directive.d.ts
+++ b/dist/img-cache.directive.d.ts
@@ -1,0 +1,10 @@
+import { ElementRef, Renderer2 } from '@angular/core';
+import { ImgCacheService } from './img-cache.service';
+export declare class ImgCacheDirective {
+    private imgCache;
+    private el;
+    private renderer;
+    constructor(imgCache: ImgCacheService, el: ElementRef, renderer: Renderer2);
+    src: any;
+    bgUrl: any;
+}

--- a/dist/img-cache.directive.js
+++ b/dist/img-cache.directive.js
@@ -1,0 +1,69 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var core_1 = require("@angular/core");
+var img_cache_service_1 = require("./img-cache.service");
+var ImgCacheDirective = /** @class */ (function () {
+    function ImgCacheDirective(imgCache, el, renderer) {
+        this.imgCache = imgCache;
+        this.el = el;
+        this.renderer = renderer;
+    }
+    Object.defineProperty(ImgCacheDirective.prototype, "src", {
+        set: function (val) {
+            var _this = this;
+            if (val) {
+                this.imgCache
+                    .fetchFromCache(val)
+                    .then(function (cached) {
+                    _this.renderer.setAttribute(_this.el.nativeElement, 'src', cached);
+                });
+            }
+        },
+        enumerable: true,
+        configurable: true
+    });
+    ;
+    Object.defineProperty(ImgCacheDirective.prototype, "bgUrl", {
+        set: function (val) {
+            var _this = this;
+            if (val) {
+                this.imgCache
+                    .fetchFromCache(val)
+                    .then(function (cached) {
+                    _this.renderer.setStyle(_this.el.nativeElement, 'background-image', "url('" + cached + "')");
+                });
+            }
+        },
+        enumerable: true,
+        configurable: true
+    });
+    ;
+    var _a, _b;
+    __decorate([
+        core_1.Input('img-cache-src'),
+        __metadata("design:type", Object),
+        __metadata("design:paramtypes", [Object])
+    ], ImgCacheDirective.prototype, "src", null);
+    __decorate([
+        core_1.Input('img-cache-bg-url'),
+        __metadata("design:type", Object),
+        __metadata("design:paramtypes", [Object])
+    ], ImgCacheDirective.prototype, "bgUrl", null);
+    ImgCacheDirective = __decorate([
+        core_1.Directive({
+            selector: '[img-cache]'
+        }),
+        __metadata("design:paramtypes", [img_cache_service_1.ImgCacheService, typeof (_a = typeof core_1.ElementRef !== "undefined" && core_1.ElementRef) === "function" && _a || Object, typeof (_b = typeof core_1.Renderer2 !== "undefined" && core_1.Renderer2) === "function" && _b || Object])
+    ], ImgCacheDirective);
+    return ImgCacheDirective;
+}());
+exports.ImgCacheDirective = ImgCacheDirective;

--- a/dist/img-cache.module.d.ts
+++ b/dist/img-cache.module.d.ts
@@ -1,0 +1,2 @@
+export declare class ImgCacheModule {
+}

--- a/dist/img-cache.module.js
+++ b/dist/img-cache.module.js
@@ -1,0 +1,24 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var core_1 = require("@angular/core");
+var img_cache_directive_1 = require("./img-cache.directive");
+var img_cache_service_1 = require("./img-cache.service");
+var ImgCacheModule = /** @class */ (function () {
+    function ImgCacheModule() {
+    }
+    ImgCacheModule = __decorate([
+        core_1.NgModule({
+            declarations: [img_cache_directive_1.ImgCacheDirective],
+            exports: [img_cache_directive_1.ImgCacheDirective],
+            providers: [img_cache_service_1.ImgCacheService]
+        })
+    ], ImgCacheModule);
+    return ImgCacheModule;
+}());
+exports.ImgCacheModule = ImgCacheModule;

--- a/dist/img-cache.service.d.ts
+++ b/dist/img-cache.service.d.ts
@@ -17,6 +17,6 @@ export declare class ImgCacheService {
     fetchFromCache(url: string): Promise<string>;
     clearCache(): Promise<null>;
     private checkInitialised;
-    private cacheIfNecessary;
+    cacheIfNecessary(url: string): Promise<null>;
     replaceWithCached(url: string): Promise<string>;
 }

--- a/dist/img-cache.service.d.ts
+++ b/dist/img-cache.service.d.ts
@@ -1,0 +1,22 @@
+export interface ImgCacheConfig {
+    debug?: boolean;
+    localCacheFolder?: string;
+    useDataURI?: boolean;
+    chromeQuota?: number;
+    usePersistentCache?: boolean;
+    cacheClearSize?: number;
+    headers?: {};
+    withCredentials?: boolean;
+    skipURIencoding?: boolean;
+    cordovaFilesystemRoot?: string;
+    timeout?: number;
+}
+export declare class ImgCacheService {
+    private promise;
+    init(config?: ImgCacheConfig): Promise<{}>;
+    fetchFromCache(url: string): Promise<string>;
+    clearCache(): Promise<null>;
+    private checkInitialised;
+    private cacheIfNecessary;
+    replaceWithCached(url: string): Promise<string>;
+}

--- a/dist/img-cache.service.js
+++ b/dist/img-cache.service.js
@@ -1,0 +1,68 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var core_1 = require("@angular/core");
+var ImgCache = require("@chrisben/imgcache.js");
+var ImgCacheService = /** @class */ (function () {
+    function ImgCacheService() {
+    }
+    ImgCacheService.prototype.init = function (config) {
+        if (config === void 0) { config = {}; }
+        Object.assign(ImgCache.options, config);
+        this.promise = new Promise(function (resolve, reject) {
+            ImgCache.init(resolve, reject);
+        });
+        return this.promise;
+    };
+    ImgCacheService.prototype.fetchFromCache = function (url) {
+        var _this = this;
+        return Promise.resolve()
+            .then(function () { return _this.checkInitialised(); })
+            .then(function () { return _this.cacheIfNecessary(url); })
+            .then(function () { return _this.replaceWithCached(url); })
+            .catch(function (err) {
+            console.warn(err);
+            return url;
+        });
+    };
+    ImgCacheService.prototype.clearCache = function () {
+        return new Promise(function (resolve, reject) {
+            ImgCache.clearCache(resolve, reject);
+        });
+    };
+    ImgCacheService.prototype.checkInitialised = function () {
+        if (!this.promise) {
+            throw new Error('ImgCache has not been initialised. Please call `init` before using the library.');
+        }
+    };
+    ImgCacheService.prototype.cacheIfNecessary = function (url) {
+        return new Promise(function (resolve, reject) {
+            // Check if image is cached
+            ImgCache.isCached(url, function (path, success) {
+                if (success) {
+                    // already cached
+                    resolve();
+                }
+                else {
+                    // not there, need to cache the image
+                    ImgCache.cacheFile(url, resolve, reject);
+                }
+            });
+        });
+    };
+    ImgCacheService.prototype.replaceWithCached = function (url) {
+        return new Promise(function (resolve, reject) {
+            ImgCache.getCachedFileBase64Data(url, function (src, dest) { return resolve(dest); }, function () { return reject(new Error('Could not replace with cached file')); });
+        });
+    };
+    ImgCacheService = __decorate([
+        core_1.Injectable()
+    ], ImgCacheService);
+    return ImgCacheService;
+}());
+exports.ImgCacheService = ImgCacheService;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,3 @@
+export * from './img-cache.module';
+export * from './img-cache.directive';
+export * from './img-cache.service';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,8 @@
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./img-cache.module"));
+__export(require("./img-cache.directive"));
+__export(require("./img-cache.service"));

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@angular/platform-browser": "^4.1.2",
     "rimraf": "^2.6.1",
     "rxjs": "^5.4.0",
-    "typescript": "^2.3.2",
+    "typescript": "^2.9.2",
     "zone.js": "^0.8.10"
   },
   "dependencies": {

--- a/src/img-cache.service.ts
+++ b/src/img-cache.service.ts
@@ -51,7 +51,7 @@ export class ImgCacheService {
     }
   }
 
-  private cacheIfNecessary(url: string): Promise<null> {
+  public cacheIfNecessary(url: string): Promise<null> {
     return new Promise((resolve, reject) => {
       // Check if image is cached
       ImgCache.isCached(url, (path, success) => {

--- a/src/img-cache.service.ts
+++ b/src/img-cache.service.ts
@@ -66,7 +66,7 @@ export class ImgCacheService {
     })
   }
 
-  private replaceWithCached(url: string): Promise<string> {
+  public replaceWithCached(url: string): Promise<string> {
     return new Promise((resolve, reject) => {
       ImgCache.getCachedFileBase64Data(
         url,

--- a/src/img-cache.service.ts
+++ b/src/img-cache.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import * as ImgCache from 'imgcache.js';
+import * as ImgCache from '@chrisben/imgcache.js';
 
 export interface ImgCacheConfig {
   debug?: boolean,                 /* call the log method ? */

--- a/src/img-cache.service.ts
+++ b/src/img-cache.service.ts
@@ -68,7 +68,7 @@ export class ImgCacheService {
 
   private replaceWithCached(url: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      ImgCache.getCachedFileURL(
+      ImgCache.getCachedFileBase64Data(
         url,
         (src, dest) => resolve(dest),
         () => reject(new Error('Could not replace with cached file'))


### PR DESCRIPTION
cacheIfNecessaryとreplaceWithCachedをprivateからpublicに変更
インポートするimgcache.jsを@chrisben/imgcache.jsに変更（最新が取れないため）
replaceWithCachedで使用するimgcache.jsのメソッドをbase64変換のメソッドに変更